### PR TITLE
Fix github-actions CI config

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -30,20 +30,23 @@ jobs:
         with:
           username: alleninstitutepika
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Determine github branch name
+        shell: bash
+        run: echo "GH_BRANCH_NAME=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_ENV
       - name: Build Docker Image
         run: |
           git clone https://github.com/AllenInstitute/ecephys_etl_pipelines.git
           cd ecephys_etl_pipelines
-          echo "Using branch $GITHUB_HEAD_REF"
-          git checkout $GITHUB_HEAD_REF
-          docker build --build-arg ECEPHYS_ETL_TAG=${GITHUB_HEAD_REF} --build-arg ECEPHYS_ETL_COMMIT_SHA=${GITHUB_SHA} --tag alleninstitutepika/ecephys_etl_pipelines:$GITHUB_SHA docker/
+          echo "Using branch ${{ env.GH_BRANCH_NAME }}"
+          git checkout "${{ env.GH_BRANCH_NAME }}"
+          docker build --build-arg ECEPHYS_ETL_TAG="${{ env.GH_BRANCH_NAME }}" --build-arg ECEPHYS_ETL_COMMIT_SHA=${GITHUB_SHA} --tag alleninstitutepika/ecephys_etl_pipelines:$GITHUB_SHA docker/
       - name: Run Tests in Docker Image
         run: |
           set -e
           docker run --entrypoint /bin/bash --read-only --tmpfs /tmp alleninstitutepika/ecephys_etl_pipelines:$GITHUB_SHA /repos/ecephys_etl/.github/scripts/general_container_test.sh
       - name: Push Docker Image
         run: |
-            if [[ "$GITHUB_HEAD_REF" == "main" ]]
+            if [[ "${{ env.GH_BRANCH_NAME }}" == "main" ]]
             then
                 docker tag alleninstitutepika/ecephys_etl_pipelines:$GITHUB_SHA alleninstitutepika/ecephys_etl_pipelines:main
             else

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,9 @@ LABEL description="This dockerfile provides a working environment for \
                    electrophysiology data processing pipelines."
 
 ARG ECEPHYS_ETL_TAG=main
+ARG ECEPHYS_ETL_COMMIT_SHA="unknown build"
 
+ENV ECEPHYS_ETL_COMMIT_SHA=${ECEPHYS_ETL_COMMIT_SHA}
 ENV CONDA_ENVS=/envs
 ENV ECEPHYS_ETL_ENV=${CONDA_ENVS}/ecephys_etl
 


### PR DESCRIPTION
This PR is meant to resolve docker images not building after merging a PR into `main`:
https://github.com/AllenInstitute/ecephys_etl_pipelines/runs/2747687614 (example failure)

Previously, the github-actions config was using the `GITHUB_HEAD_REF`
environment variable to determine branch name. Unfortunately,
this variable is only set for pull requests causing the
associated docker build step to fail for when the "main" branch
tries to build a docker image.

The solution is to use bash parameter expansion to both:
1) Default to using `GITHUB_HEAD_REF` if it exists otherwise use `GITHUB_REF`
2) Use `GITHUB_REF` after trimming with parameter expansion since
   it takes on values like `refs/heads/feature-branch-1` and we
   only want the `feature-branch-1` part of the string.

Further reading:
https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables
https://wiki.bash-hackers.org/syntax/pe