### PR TITLE
Add tests to be run before creation of docker image

### DIFF
--- a/.github/workflows/github-actions-ci.yml
+++ b/.github/workflows/github-actions-ci.yml
@@ -22,7 +22,34 @@ jobs:
           echo ${CHANGED_PYFILES}
           flake8 ${CHANGED_PYFILES} --count
   
-  ecephys_etl_pipelines:
+  ecephys_etl_pipelines_tests:
+    name: ${{ matrix.python-version }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["macos-latest", "ubuntu-latest"]
+        python-version: ["3.8"]
+      fail-fast: false
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test-env
+      - name: Install
+        run: |
+          conda activate test-env
+          pip install .[test]
+      - name: Test
+        run: |
+          pytest --cov
+
+  ecephys_etl_pipelines_docker:
+    needs: [lint, ecephys_etl_pipelines_tests]
     runs-on: "ubuntu-latest"
     steps:
       - name: Login to DockerHub

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     python_requires=">=3.8",
     setup_requires=["setuptools_scm"],
     install_requires=requirements,
-    extras_requires={
+    extras_require={
         "test": test_requirements
     }
 )


### PR DESCRIPTION
Adds a new `ecephys_etl_pipelines_tests` job to the github-actions
jobs. The old `ecephys_etl_pipelines` job has been renamed to
`ecephys_etl_pipelines_docker` and now has dependencies on
`lint` and `ecephys_etl_pipelines_tests` jobs.