### PR TITLE
Ticket/39/omissions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-argschema<3.0.0
+argschema>=3.0.1,<4.0.0
 h5py
 numpy
 scipy

--- a/src/ecephys_etl/data_transformers/visual_behavior_stimulus_processing.py
+++ b/src/ecephys_etl/data_transformers/visual_behavior_stimulus_processing.py
@@ -156,11 +156,6 @@ def get_visual_stimuli_df(data, time) -> pd.DataFrame:
             )
 
             for idx, (epoch_start, epoch_end,) in enumerate(draw_epochs):
-                # visual stimulus doesn't actually change until start of
-                # following frame, so we need to bump the
-                # epoch_start & epoch_end to get the timing right
-                epoch_start += 1
-                epoch_end += 1
 
                 visual_stimuli_data.append({
                     "orientation": orientation,

--- a/src/ecephys_etl/modules/vbn_create_stimulus_table/__main__.py
+++ b/src/ecephys_etl/modules/vbn_create_stimulus_table/__main__.py
@@ -37,7 +37,8 @@ class VbnCreateStimulusTable(argschema.ArgSchemaParser):
             sync_dataset=sync_data,
             behavior_pkl=behavior_data,
             mapping_pkl=mapping_data,
-            replay_pkl=replay_data
+            replay_pkl=replay_data,
+            frame_time_offset=self.args["frame_time_offset"]
         )
         stim_table.to_csv(path_or_buf=output_path, index=False)
 

--- a/src/ecephys_etl/modules/vbn_create_stimulus_table/create_stim_table.py
+++ b/src/ecephys_etl/modules/vbn_create_stimulus_table/create_stim_table.py
@@ -1215,7 +1215,8 @@ def create_vbn_stimulus_table(
     sync_dataset: Dataset,
     behavior_pkl: BehaviorPickleFile,
     mapping_pkl: CamStimOnePickleStimFile,
-    replay_pkl: ReplayPickleFile
+    replay_pkl: ReplayPickleFile,
+    frame_time_offset: float = 0.0,
 ) -> pd.DataFrame:
     """Create a stimulus table that encompasses all 'blocks' of stimuli
     presented during a visual behavior neuropixels session
@@ -1236,6 +1237,9 @@ def create_vbn_stimulus_table(
     replay_pkl : ReplayPickleFile
         A ReplayPickleFile object, that allows easier access to key
         replay pickle file data and metadata.
+    frame_time_offset: float
+        Offset (in seconds) to be added to the start_time and stop_time
+        columns to accommodate hardware behavior
 
     Returns
     -------
@@ -1290,5 +1294,8 @@ def create_vbn_stimulus_table(
 
     full_stim_df = pd.concat([behavior_df, mapping_df, replay_df], sort=False)
     full_stim_df.reset_index(drop=True, inplace=True)
+
+    full_stim_df.start_time += frame_time_offset
+    full_stim_df.stop_time += frame_time_offset
 
     return full_stim_df

--- a/src/ecephys_etl/modules/vbn_create_stimulus_table/schemas.py
+++ b/src/ecephys_etl/modules/vbn_create_stimulus_table/schemas.py
@@ -1,5 +1,5 @@
 from argschema import ArgSchema
-from argschema.fields import (LogLevel, InputFile, Nested, OutputFile)
+from argschema.fields import (LogLevel, InputFile, Nested, OutputFile, Float)
 
 from ecephys_etl.schemas.fields import OutputFileExists
 
@@ -44,6 +44,16 @@ class VbnCreateStimulusTableInputSchema(ArgSchema):
             "rewards."
         )
     )
+    frame_time_offset = Float(
+        required=False,
+        default=0.008,
+        allow_none=False,
+        description=(
+            "Scalar value (in seconds) to be added to the "
+            "start_time and stop_time columns based on empirical "
+            "hardware measurements (default value is taken from "
+            "experiments done leading up to the VBN 2022 data "
+            "release)"))
     output_stimulus_table_path = OutputFile(
         required=True,
         description=(

--- a/tests/data_transformers/test_visual_behavior_stimulus_processing.py
+++ b/tests/data_transformers/test_visual_behavior_stimulus_processing.py
@@ -177,15 +177,15 @@ def test_get_draw_epochs(behavior_stimuli_data_fixture,
                                           ([0] + [1] * 3 + [0] * 3)
                                           * 2 + [0])},
                               {"duration": [3.0, 2.0, 3.0, 2.0],
-                               "end_frame": [5.0, 5.0, 12.0, 12.0],
+                               "end_frame": [4.0, 4.0, 11.0, 11.0],
                                "image_name": [np.NaN, 'im065', np.NaN,
                                               'im064'],
                                "index": [2, 0, 3, 1],
                                "omitted": [False, False, False, False],
                                "orientation": [90, np.NaN, 270, np.NaN],
-                               "start_frame": [2.0, 3.0, 9.0, 10.0],
-                               "start_time": [2, 3, 9, 10],
-                               "stop_time": [5, 5, 12, 12]})
+                               "start_frame": [1.0, 2.0, 8.0, 9.0],
+                               "start_time": [1, 2, 8, 9],
+                               "stop_time": [4, 4, 11, 11]})
                          ], indirect=['behavior_stimuli_time_fixture',
                                       'behavior_stimuli_data_fixture'])
 def test_get_stimulus_presentations(behavior_stimuli_time_fixture,
@@ -196,8 +196,9 @@ def test_get_stimulus_presentations(behavior_stimuli_time_fixture,
         behavior_stimuli_time_fixture)
 
     expected_df = pd.DataFrame.from_dict(expected)
+    expected_df.index.name = 'stimulus_presentations_id'
 
-    assert presentations_df.equals(expected_df)
+    pd.testing.assert_frame_equal(presentations_df, expected_df)
 
 
 @pytest.mark.parametrize("behavior_stimuli_time_fixture,"
@@ -219,9 +220,9 @@ def test_get_stimulus_presentations(behavior_stimuli_time_fixture,
                                           * 2 + [0])},
                               {"orientation": [90, None, 270, None],
                                "image_name": [None, 'im065', None, 'im064'],
-                               "frame": [2.0, 3.0, 9.0, 10.0],
-                               "end_frame": [5.0, 5.0, 12.0, 12.0],
-                               "time": [2.0, 3.0, 9.0, 10.0],
+                               "frame": [1.0, 2.0, 8.0, 9.0],
+                               "end_frame": [4.0, 4.0, 11.0, 11.0],
+                               "time": [1.0, 2.0, 8.0, 9.0],
                                "duration": [3.0, 2.0, 3.0, 2.0],
                                "omitted": [False, False, False, False]}),
 
@@ -243,9 +244,9 @@ def test_get_stimulus_presentations(behavior_stimuli_time_fixture,
                                           [0] * 17 + [1] * 11 + [0, 0])},
                               {"orientation": [None, None, 90, 270],
                                "image_name": ['im065', 'im064', None, None],
-                               "frame": [3.0, 10.0, 18.0, 25.0],
-                               "end_frame": [5.0, 12.0, 25.0, 29.0],
-                               "time": [3.0, 10.0, 18.0, 25.0],
+                               "frame": [2.0, 9.0, 17.0, 24.0],
+                               "end_frame": [4.0, 11.0, 24.0, 28.0],
+                               "time": [2.0, 9.0, 17.0, 24.0],
                                "duration": [2.0, 2.0, 7.0, 4.0],
                                "omitted": [False, False, False, False]})
                          ],
@@ -259,4 +260,4 @@ def test_get_visual_stimuli_df(behavior_stimuli_time_fixture,
     stimuli_df = stimuli_df.drop('index', axis=1)
 
     expected_df = pd.DataFrame.from_dict(expected_data)
-    assert stimuli_df.equals(expected_df)
+    pd.testing.assert_frame_equal(stimuli_df, expected_df)

--- a/tests/modules/vbn_create_stimulus_table/test_vbn_create_stimulus_table_module.py
+++ b/tests/modules/vbn_create_stimulus_table/test_vbn_create_stimulus_table_module.py
@@ -117,7 +117,8 @@ def test_vbn_create_stimulus_table(
         sync_dataset=MockDataset.return_value,
         behavior_pkl=MockBehaviorPickleFile.factory.return_value,
         mapping_pkl=MockCamStimOnePickleStimFile.factory.return_value,
-        replay_pkl=MockReplayPickleFile.factory.return_value
+        replay_pkl=MockReplayPickleFile.factory.return_value,
+        frame_time_offset=0.008
     )
 
     assert output_path.exists()


### PR DESCRIPTION
As per the discussion in #39, the original stimulus processing code introduced a spurious one-frame offset into the timing of stimulus presentation data. This PR removes that offset. It also adds a command line parameter allowing users to add a by-hand offset in timing to better bring stimulus timestamps in line with what the mouse sees while in the rig. Based on experimentation with real data, Corbett Bennett has determined that an 8 millisecond offset between the timestamp recorded in the sync file and the timestamp recorded in the stimulus table is appropriate.